### PR TITLE
afl-fuzz: automatically remove the child pid file created by drrun to keep the directory clean

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2101,6 +2101,7 @@ static void create_target_process(char** argv) {
   fread(buf, pidsize, 1, fp);
   buf[pidsize] = 0;
   fclose(fp);
+  remove(pidfile);
 
   child_pid = atoi(buf);
 


### PR DESCRIPTION
This is a very simple PR that deletes the childpid file created by drrun to allow afl-fuzz to grab the pid of the instrumented target. Once the file is read, it is of no use and can be deleted in order to keep the current "clean".
It is even more useful for the afl-cmin/showmap scenario where you instrument the target with a fuzz_iteration = 1, so you basically end up with one childpid file per samples which is very annoying.

Cheers