### PR TITLE
winafl: use a case insensitive string compare function, and ease debugging coverage related settings with extra logging messages

### DIFF
--- a/winafl.c
+++ b/winafl.c
@@ -197,6 +197,7 @@ static dr_emit_flags_t
 instrument_bb_coverage(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                       bool for_trace, bool translating, void *user_data)
 {
+    static bool debug_information_output = false;
     app_pc start_pc;
     module_entry_t **mod_entry_cache;
     module_entry_t *mod_entry;
@@ -222,8 +223,12 @@ instrument_bb_coverage(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
     should_instrument = false;
     target_modules = options.target_modules;
     while(target_modules) {
-        if(strcmp(module_name, target_modules->module_name) == 0) {
+        if(_stricmp(module_name, target_modules->module_name) == 0) {
             should_instrument = true;
+            if(options.debug_mode && debug_information_output == false) {
+                dr_fprintf(winafl_data.log, "Instrumenting %s with the 'bb' mode\n", module_name);
+                debug_information_output = true;
+            }
             break;
         }
         target_modules = target_modules->next;
@@ -248,6 +253,7 @@ static dr_emit_flags_t
 instrument_edge_coverage(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                       bool for_trace, bool translating, void *user_data)
 {
+    static bool debug_information_output = false;
     app_pc start_pc;
     module_entry_t **mod_entry_cache;
     module_entry_t *mod_entry;
@@ -279,8 +285,12 @@ instrument_edge_coverage(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
     should_instrument = false;
     target_modules = options.target_modules;
     while(target_modules) {
-        if(strcmp(module_name, target_modules->module_name) == 0) {
+        if(_stricmp(module_name, target_modules->module_name) == 0) {
             should_instrument = true;
+            if(options.debug_mode && debug_information_output == false) {
+                dr_fprintf(winafl_data.log, "Instrumenting %s with the 'edge' mode\n", module_name);
+                debug_information_output = true;
+            }
             break;
         }
         target_modules = target_modules->next;


### PR DESCRIPTION
This commit replaces the case sensitive `strcmp` by the case insensitive equivalent function and logs more messages when using the debug mode.

I've had several times where the preferred module name happened to be in uppercase and/or different from the actual filename (assuming you have a debug record in the PE and in this case this name will be used instead); debugging this can be a little bit annoying as the debug mode did not log any information related to the coverage settings which is what I'm trying to address here.

Let me know if you think using `_stricmp` might lead to issues I haven't thought about :).

Cheers