### PR TITLE
winafl: use exe_name instead of the preferred name

### DIFF
--- a/winafl.c
+++ b/winafl.c
@@ -469,8 +469,13 @@ event_module_unload(void *drcontext, const module_data_t *info)
 static void
 event_module_load(void *drcontext, const module_data_t *info, bool loaded)
 {
-    const char *module_name = dr_module_preferred_name(info);
+    const char *module_name = info->names.exe_name;
     app_pc to_wrap;
+
+    if (module_name == NULL) {
+        // In case exe_name is not defined, we will fall back on the preferred name.
+        module_name = dr_module_preferred_name(info);
+    }
 
     if(options.debug_mode)
         dr_fprintf(winafl_data.log, "Module loaded, %s\n", module_name);


### PR DESCRIPTION
This PR modifies winafl so that it uses the executable name as the name of the module - as opposed to the "preferred" name. The preferred name can be found in the PE headers of the executable in the Debug directory for some of them.

One example is to take 'test.exe', to rename it to 'foo.exe'; winafl will still consider the module 'foo.exe' as 'test.exe' which is super annoying and confusing.