### PR TITLE
VS2015 Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,4 +54,8 @@ use_DynamoRIO_extension(winafl drx)
 use_DynamoRIO_extension(winafl drcontainers)
 use_DynamoRIO_extension(winafl drreg)
 use_DynamoRIO_extension(winafl drwrap)
+# VS2015 Fix
+target_link_libraries(winafl "libucrt.lib")
+target_link_libraries(winafl "libvcruntime.lib")
+
 


### PR DESCRIPTION
Small Patch for VS2015. Please let me know if you'd like a VC >= 1900 check statement before the target_link_libraries statement. 

Related Issue: https://github.com/ivanfratric/winafl/issues/10

Thanks!