### PR TITLE
Allocate and free orig_in with ck_* methods

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4677,7 +4677,7 @@ static u8 fuzz_one(char** argv) {
 
   len = queue_cur->len;
 
-  orig_in = in_buf = (u8 *)malloc(len);
+  orig_in = in_buf = (u8 *)ck_alloc_nozero(len);
   _read(fd, in_buf, len);
 
   close(fd);
@@ -6261,6 +6261,7 @@ abandon_entry:
   }
 
   if (in_buf != orig_in) ck_free(in_buf);
+  ck_free(orig_in);
   ck_free(out_buf);
   ck_free(eff_map);
 


### PR DESCRIPTION
I've started to play with winafl so take this pull request carefully, I could be wrong, feedback is welcome =)

The changes:

* Use ```ck_alloc_nozero```  instead of ```malloc``` to allocate the ```orig_in``` memory in ```fuzz_one```. I'm not really sure if there is a good reason to use plain ```malloc``` instead of "ck_alloc_nozero". I could be missing it, feel free to say :). Since original afl uses mmap and checks for errors I guess using "ck_alloc_nozero" could be a good idea :)

```
  orig_in = in_buf = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);

  if (orig_in == MAP_FAILED) PFATAL("Unable to mmap '%s'", queue_cur->fname);
```

* free orig_in: Original afl takes care of unmap'ing ```orig_in``` before returning from ```fuzz_one```:

```
  munmap(orig_in, queue_cur->len);

  if (in_buf != orig_in) ck_free(in_buf);
```

I think would be a good idea to also free ```orig_in``` before returning from ```fuzz_one``` on winafl. Again, I could be missing something, feedback is super welcome. I'm just starting to play with winafl :) 

Last but not least, thanks to everybody who worked in this port! Great work!