### PR TITLE
Porting AFL improvements to WinAFL.

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -102,8 +102,7 @@ static u8  skip_deterministic,        /* Skip deterministic stages?       */
            bitmap_changed = 1,        /* Time to update bitmap?           */
            qemu_mode,                 /* Running in QEMU mode?            */
            skip_requested,            /* Skip request, via SIGUSR1        */
-           run_over10m,               /* Run time over 10 minutes?        */
-           persistent_mode = 0;       /* Running in persistent mode?      */
+           run_over10m;               /* Run time over 10 minutes?        */
 
 static s32 out_fd,                    /* Persistent fd for out_file       */
            dev_urandom_fd = -1,       /* Persistent fd for /dev/urandom   */
@@ -4010,7 +4009,7 @@ static void show_stats(void) {
     else strcpy(tmp, "n/a");
 
   SAYF(" stability : %s%-10s " bSTG bV "\n", stab_ratio < 90 ? cLRD :
-          ((queued_variable && !persistent_mode) ? cMGN : cRST), tmp);
+          (queued_variable ? cMGN : cRST), tmp);
 
   if (!bytes_trim_out) {
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -6021,10 +6021,10 @@ havoc_stage:
 
           }
 
-        /* Values 16 and 17 can be selected only if there are any extras
+        /* Values 15 and 16 can be selected only if there are any extras
            present in the dictionaries. */
 
-        case 16: {
+        case 15: {
 
             /* Overwrite bytes with an extra. */
 
@@ -6061,7 +6061,7 @@ havoc_stage:
 
           }
 
-        case 17: {
+        case 16: {
 
             u32 use_extra, extra_len, insert_at = UR(temp_len);
             u8* new_buf;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4032,7 +4032,7 @@ static void show_stats(void) {
   if (t_bytes) sprintf(tmp, "%0.02f%%", stab_ratio);
     else strcpy(tmp, "n/a");
 
-  SAYF(" stability : %s%-10s " bSTG bV "\n", (stab_ratio < 85 && var_byte_count > 40)
+  SAYF(" stability : %s%-9s " bSTG bV "\n", (stab_ratio < 85 && var_byte_count > 40)
        ? cLRD : ((queued_variable && (!persistent_mode || var_byte_count > 20))
        ? cMGN : cRST), tmp);
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4004,8 +4004,6 @@ static void show_stats(void) {
           DI(stage_finds[STAGE_HAVOC]), DI(stage_cycles[STAGE_HAVOC]),
           DI(stage_finds[STAGE_SPLICE]), DI(stage_cycles[STAGE_SPLICE]));
 
-  sprintf(tmp, "%s (%0.02f%%)", DI(t_bytes), t_byte_ratio);
-
   SAYF(bV bSTOP "       havoc : " cRST "%-37s " bSTG bV bSTOP, tmp);
 
   if (t_bytes) sprintf(tmp, "%0.02f%%", stab_ratio);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7247,12 +7247,7 @@ int main(int argc, char** argv) {
         dynamorio_dir = optarg;
         break;
 
-      case 'M':
-
-        force_deterministic = 1;
-        /* Fall through */
-
-      case 'S': { /* secondary sync ID */
+      case 'M': { /* master sync ID */
 
           u8* c;
 
@@ -7269,9 +7264,10 @@ int main(int argc, char** argv) {
 
           }
 
-        }
+          force_deterministic = 1;
+          fuzzer_id = sync_id;
 
-        fuzzer_id = sync_id;
+        }
         break;
 
       case 'f': /* target file */

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -102,7 +102,8 @@ static u8  skip_deterministic,        /* Skip deterministic stages?       */
            bitmap_changed = 1,        /* Time to update bitmap?           */
            qemu_mode,                 /* Running in QEMU mode?            */
            skip_requested,            /* Skip request, via SIGUSR1        */
-           run_over10m;               /* Run time over 10 minutes?        */
+           run_over10m,               /* Run time over 10 minutes?        */
+           persistent_mode;           /* Running in persistent mode?      */
 
 static s32 out_fd,                    /* Persistent fd for out_file       */
            dev_urandom_fd = -1,       /* Persistent fd for /dev/urandom   */
@@ -4008,8 +4009,9 @@ static void show_stats(void) {
   if (t_bytes) sprintf(tmp, "%0.02f%%", stab_ratio);
     else strcpy(tmp, "n/a");
 
-  SAYF(" stability : %s%-10s " bSTG bV "\n", stab_ratio < 90 ? cLRD :
-          (queued_variable ? cMGN : cRST), tmp);
+  SAYF(" stability : %s%-10s " bSTG bV "\n", (stab_ratio < 85 && var_byte_count > 40)
+       ? cLRD : ((queued_variable && (!persistent_mode || var_byte_count > 20))
+       ? cMGN : cRST), tmp);
 
   if (!bytes_trim_out) {
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -100,6 +100,7 @@ static u8  skip_deterministic,        /* Skip deterministic stages?       */
            in_place_resume,           /* Attempt in-place resume?         */
            auto_changed,              /* Auto-generated tokens changed?   */
            no_cpu_meter_red,          /* Feng shui on the status screen   */
+           no_arith,                  /* Skip most arithmetic ops         */
            shuffle_queue,             /* Shuffle input queue?             */
            bitmap_changed = 1,        /* Time to update bitmap?           */
            qemu_mode,                 /* Running in QEMU mode?            */
@@ -5175,6 +5176,8 @@ static u8 fuzz_one(char** argv) {
 
 skip_bitflip:
 
+  if (no_arith) goto skip_arith;
+
   /**********************
    * ARITHMETIC INC/DEC *
    **********************/
@@ -5488,7 +5491,7 @@ skip_arith:
 
   /* Setting 16-bit integers, both endians. */
 
-  if (len < 2) goto skip_interest;
+  if (no_arith || len < 2) goto skip_interest;
 
   stage_name  = "interest 16\\8";
   stage_short = "int16";
@@ -7464,6 +7467,7 @@ int main(int argc, char** argv) {
 
   if (getenv("AFL_NO_FORKSRV"))    no_forkserver    = 1;
   if (getenv("AFL_NO_CPU_RED"))    no_cpu_meter_red = 1;
+  if (getenv("AFL_NO_ARITH"))      no_arith = 1;
   if (getenv("AFL_SHUFFLE_QUEUE")) shuffle_queue    = 1;
   if (getenv("AFL_NO_SINKHOLE"))   sinkhole_stds    = 0;
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5619,6 +5619,11 @@ skip_interest:
 
     for (j = 0; j < extras_cnt; j++) {
 
+      if (len + extras[j].len > MAX_FILE) {
+        stage_max--;
+        continue;
+      }
+
       /* Insert token */
       memcpy(ex_tmp + i, extras[j].data, extras[j].len);
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4199,7 +4199,7 @@ static void show_init_stats(void) {
      limit is very expensive, so let's select a more conservative default. */
 
   if (dumb_mode && !getenv("AFL_HANG_TMOUT"))
-    hang_tmout = exec_tmout * 4;
+    hang_tmout = MIN(EXEC_TIMEOUT, exec_tmout * 2 + 100);
 
   OKF("All set and ready to roll!");
 

--- a/config.h
+++ b/config.h
@@ -112,6 +112,10 @@
 #define HAVOC_BLK_MEDIUM    128
 #define HAVOC_BLK_LARGE     1500
 
+/* Extra-large blocks, selected very rarely (<2% of the time): */
+
+#define HAVOC_BLK_XL        16384
+
 /* Probabilities of skipping non-favored entries in the queue, expressed as
    percentages: */
 

--- a/config.h
+++ b/config.h
@@ -66,14 +66,10 @@
 /* Number of calibration cycles per every new test case (and for test
    cases that show variable behavior): */
 
-#define CAL_CYCLES          10
+#define CAL_CYCLES          8
 #define CAL_CYCLES_LONG     40
 
-/* The same, but when AFL_NO_VAR_CHECK is set in the environment: */
-
-#define CAL_CYCLES_NO_VAR   4
-
-/* Number of subsequent hangs before abandoning an input file: */
+/* Number of subsequent timeouts before abandoning an input file: */
 
 #define HANG_LIMIT          250
 

--- a/config.h
+++ b/config.h
@@ -43,7 +43,8 @@
 
 //#define FANCY_BOXES
 
-/* Default timeout for fuzzed code (milliseconds): */
+/* Default timeout for fuzzed code (milliseconds). This is the upper bound,
+   also used for detecting hangs; the actual value is auto-scaled: */
 
 #define EXEC_TIMEOUT        1000
 
@@ -71,7 +72,7 @@
 
 /* Number of subsequent timeouts before abandoning an input file: */
 
-#define HANG_LIMIT          250
+#define TMOUT_LIMIT         250
 
 /* Maximum number of unique hangs or crashes to record: */
 
@@ -112,9 +113,9 @@
 #define HAVOC_BLK_MEDIUM    128
 #define HAVOC_BLK_LARGE     1500
 
-/* Extra-large blocks, selected very rarely (<2% of the time): */
+/* Extra-large blocks, selected very rarely (<5% of the time): */
 
-#define HAVOC_BLK_XL        16384
+#define HAVOC_BLK_XL        32768
 
 /* Probabilities of skipping non-favored entries in the queue, expressed as
    percentages: */

--- a/config.h
+++ b/config.h
@@ -80,7 +80,9 @@
 
 /* Baseline number of random tweaks during a single 'havoc' stage: */
 
-#define HAVOC_CYCLES        5000
+#define HAVOC_CYCLES        256
+#define HAVOC_CYCLES_INIT   1024
+
 
 /* Maximum multiplier for the above (should be a power of two, beware
    of 32-bit int overflows): */
@@ -89,7 +91,7 @@
 
 /* Absolute minimum number of havoc cycles (after all adjustments): */
 
-#define HAVOC_MIN           10
+#define HAVOC_MIN           16
 
 /* Maximum stacking for havoc-stage tweaks. The actual value is calculated
    like this: 
@@ -119,11 +121,11 @@
 
 /* Splicing cycle count: */
 
-#define SPLICE_CYCLES       20
+#define SPLICE_CYCLES       15
 
 /* Nominal per-splice havoc cycle length: */
 
-#define SPLICE_HAVOC        500
+#define SPLICE_HAVOC        32
 
 /* Maximum offset for integer addition / subtraction stages: */
 


### PR DESCRIPTION
This PR introduces a bunch of bug-fixes, and various improvements coming from the versions > 1.96b (stability indicator, parallelizing of deterministic steps, aflfast tweaks, etc.).

Here are the different commits I've ported:

- 2.02b: https://github.com/mirrorer/afl/commit/13c63f858c5f8d72d160a6bfe6d58928948d1597

- 2.11b: https://github.com/mirrorer/afl/commit/12eeeeaf48576c925db5013fa8dd4613649de144

- 2.18b: https://github.com/mirrorer/afl/commit/81680ec6c09b99aa76e6241533fe9706e00703dd

- 2.20b: https://github.com/mirrorer/afl/commit/8b3079a5fe75242f3c9300ece0833e3a1a04b0c9

- 2.21b: https://github.com/mirrorer/afl/commit/8b3079a5fe75242f3c9300ece0833e3a1a04b0c9

- 2.22b: https://github.com/mirrorer/afl/commit/2e8d7564af707f0693a346a8d39e2effb409099d

- 2.23b: https://github.com/mirrorer/afl/commit/f09079134d864226a812b68182e5cefd3994e961

- 2.30b: https://github.com/mirrorer/afl/commit/23710f17057353de4a6c9affe385e0f1ce4fb5c3

- 2.31b/2.32b: https://github.com/mirrorer/afl/commit/b31509551932c8af7bf330632e0966757a537c46 & https://github.com/mirrorer/afl/commit/602a7de00602b3d37c5803f793fffa5f8a34030f

- 2.36b: https://github.com/mirrorer/afl/commit/70101a3e5be86c0ddb2f86e4881c36dd1acc3ac1

- 2.40b: https://github.com/mirrorer/afl/commit/0e4298bf270bf7584273a5f7c31cb17e53c01e6d

- 2.41b: https://github.com/mirrorer/afl/commit/a8aa47c941e120af6dd86a6b756852926a7a245f

- 2.42b: https://github.com/mirrorer/afl/commit/85db01c0d7790c3f14ad66d9d875ea5b42594204

- 2.43b: https://github.com/mirrorer/afl/commit/e6d433038852b7cc13e6291779a2ac55aaa8ede9

 I could also use a second pair of eyes to double check the above :).

Cheers 