### PR TITLE
Fixed missing last_crash_time

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -3075,6 +3075,8 @@ static u8 save_if_interesting(char** argv, void* mem, u32 len, u8 fault) {
 
       unique_crashes++;
 
+      last_crash_time = get_cur_time();
+
       last_crash_execs = total_execs;
 
       break;


### PR DESCRIPTION
last_crash_time is missing probably due to porting from afl