### PR TITLE
Added support of network applications fuzzing via UDP

### DIFF
--- a/config.h
+++ b/config.h
@@ -52,6 +52,11 @@
 
 #define EXEC_TM_ROUND       20
 
+/* Defauly delay in milliseconds to let the target open a socket and start listen for
+   incoming packages.
+ */
+#define SOCKET_INIT_DELAY 30000
+
 /* Default memory limit for child process (MB): */
 
 #ifndef __x86_64__ 

--- a/winafl.c
+++ b/winafl.c
@@ -76,6 +76,7 @@ typedef struct _winafl_option_t {
     int num_fuz_args;
     drwrap_callconv_t callconv;
     bool thread_coverage;
+    bool enable_socket_fuzzing;
 } winafl_option_t;
 static winafl_option_t options;
 
@@ -428,13 +429,13 @@ pre_fuzz_handler(void *wrapcxt, INOUT void **user_data)
     }
 
     //save or restore arguments
-    if(fuzz_target.iteration == 0) {
-        for(i = 0; i < options.num_fuz_args; i++) {
-            options.func_args[i] = drwrap_get_arg(wrapcxt, i);
-        }
-    } else {
-        for(i = 0; i < options.num_fuz_args; i++) {
-            drwrap_set_arg(wrapcxt, i, options.func_args[i]);
+    if (!options.enable_socket_fuzzing) {
+        if (fuzz_target.iteration == 0) {
+            for (i = 0; i < options.num_fuz_args; i++)
+                options.func_args[i] = drwrap_get_arg(wrapcxt, i);
+        } else {
+            for (i = 0; i < options.num_fuz_args; i++)
+                drwrap_set_arg(wrapcxt, i, options.func_args[i]);
         }
     }
 
@@ -461,6 +462,10 @@ post_fuzz_handler(void *wrapcxt, void *user_data)
         debug_data.post_handler_called++;
         dr_fprintf(winafl_data.log, "In post_fuzz_handler\n");
     }
+
+    /* We don't need to reload context in case of network-based fuzzing. */
+    if (options.enable_socket_fuzzing)
+        return;
 
     fuzz_target.iteration++;
     if(fuzz_target.iteration == options.fuzz_iterations) {
@@ -491,6 +496,12 @@ createfilea_interceptor(void *wrapcxt, INOUT void **user_data)
         dr_fprintf(winafl_data.log, "In OpenFileA, reading %s\n", filename);
 }
 
+static void
+recvfrom_interceptor(void *wrapcxt, INOUT void **user_data)
+{
+    if (options.debug_mode)
+        dr_fprintf(winafl_data.log, "In recvfrom\n");
+}
 
 static void
 event_module_unload(void *drcontext, const module_data_t *info)
@@ -529,6 +540,11 @@ event_module_load(void *drcontext, const module_data_t *info, bool loaded)
                 }
             }
             drwrap_wrap_ex(to_wrap, pre_fuzz_handler, post_fuzz_handler, NULL, options.callconv);
+        }
+
+        if (options.debug_mode && (strcmp(module_name, "WS2_32.dll") == 0)) {
+            to_wrap = (app_pc)dr_get_proc_address(info->handle, "recvfrom");
+            bool result = drwrap_wrap(to_wrap, recvfrom_interceptor, NULL);
         }
 
         if(options.debug_mode && (strcmp(module_name, "KERNEL32.dll") == 0)) {
@@ -646,6 +662,7 @@ options_init(client_id_t id, int argc, const char *argv[])
     options.fuzz_method[0] = 0;
     options.fuzz_offset = 0;
     options.fuzz_iterations = 1000;
+    options.enable_socket_fuzzing = false;
     options.func_args = NULL;
     options.num_fuz_args = 0;
     options.callconv = DRWRAP_CALLCONV_DEFAULT;
@@ -730,6 +747,9 @@ options_init(client_id_t id, int argc, const char *argv[])
                 options.callconv = DRWRAP_CALLCONV_MICROSOFT_X64;
             else
                 NOTIFY(0, "Unknown calling convention, using default value instead.\n");
+        }
+        else if (strcmp(token, "-socket_fuzzing") == 0) {
+            options.enable_socket_fuzzing = true;
         }
         else {
             NOTIFY(0, "UNRECOGNIZED OPTION: \"%s\"\n", token);


### PR DESCRIPTION
This patch allows AFL to do fuzzing of a target that receives data
via UDP protocol.

To be able to reduce amount of changes in WinAFL we handle recfrom
function the same way WinAFL already handles CreateFile. So, the
idea of this patch is simple: we ask WinAFL to perform required
mutation on input and then send this input over network in the
target application.

Thus requirements for the target function hasn't changed:
1. The function (or subsequent functions called from original function)
calls recvfrom.
2. The function (or subsequent functions) parses received data.
3. The function normally returns.
In addition we have one new requirement:
4. An application executes the target function in a loop to be able to
receive next incoming packages from the network.

Since our target function is executed in a loop we don't need to
interfere execution flow. However -fuzz_iterations is still used to
restart the target after specified number of iterations and need to
be specified by user.

This patch introduces three new options: -a <ip_address> -p <port> -w
<delay_in_milliseconds).

-w option is required to give the target application time to initialize
everything and open a socket for data receiving. Otherwise WinAFL might
send a packet even before the target is ready to receive that packet
thereby messing the whole process.