### PR TITLE
Fix ENABLE_VIRTUAL_TERMINAL_PROCESSING undefined

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -61,10 +61,6 @@
 #  include <sys/sysctl.h>
 #endif /* __APPLE__ || __FreeBSD__ || __OpenBSD__ */
 
-#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
-#endif
-
 /* Lots of globals, but mostly for the status UI and other things where it
    really makes no sense to haul them around as function parameters. */
 

--- a/debug.h
+++ b/debug.h
@@ -30,6 +30,10 @@
 #include "types.h"
 #include "config.h"
 
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
 /*******************
  * Terminal colors *
  *******************/


### PR DESCRIPTION
The definition of `ENABLE_VIRTUAL_TERMINAL_PROCESSING` should be in `debug.h` instead of `afl-fuzz.c` to compile on old version of Windows SDKs.