### PR TITLE
implemented in_app_persistent_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,31 @@ The target function should do these things during its lifetime:
 4. Return normally (So that WinAFL can "catch" this return and redirect
    execution. "returning" via ExitProcess() and such won't work)
 
+## In App Persistence mode
+
+This feature is a tweak for the traditional "target function" approach and aims
+to loosen the requirements of the target function to do both reading
+an input file and processing the input file.
+
+In some applications it's quite challenging to find a target function
+that with a simple execution redirection won't break global states and will do
+both reading and processing of inputs.
+
+This mode assumes that the target application will actually loop
+the target function by itself, and will handle properly its global state
+For example a udp server handling packets or a js interpreter running inside
+a while loop.
+
+This mode works as following:
+1. Your target runs until hitting the target function.
+2. The afl server starts instrumenting the target.
+3. Your target runs until hitting the target function again.
+4. The afl server stops instrumenting current cycle and starts a new one.
+
+usage: add the following option to the winafl arguments:
+-persistence_mode in_app
+
+
 ## Corpus minimization
 
 WinAFL includes the windows port of afl-cmin in winafl-cmin.py. Please run the

--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ This mode works as following:
 usage: add the following option to the winafl arguments:
 -persistence_mode in_app
 
+example usage on the supplied test.exe:
+afl-fuzz.exe -i in -o out -D <dynamorio bin path> -t 100+ -- -coverage_module test.exe -fuzz_iterations 5000 -target_module test.exe -target_offset 0x1000 -nargs 2 -persistence_mode in_app -- test.exe @@ loop
+
 
 ## Corpus minimization
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2538,6 +2538,10 @@ static u8 run_target(char** argv, u32 timeout) {
 	  watchdog_enabled = 0;
 	  return FAULT_NONE;
   }
+  if (result != 'P')
+  {
+	  FATAL("Unexpected result from pipe! expected 'P', instead received '%c'\n", result);
+  }
   WriteCommandToPipe('F');
 
   result = ReadCommandFromPipe(timeout); //no need to check for "error(0)" since we are exiting anyway

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -75,7 +75,7 @@ static u8 *in_dir,                    /* Input directory with test cases  */
           *target_path,               /* Path to target binary            */
           *target_cmd,                /* command line of target           */
           *orig_cmdline;              /* Original command line            */
-
+static u32 app_persistent_mode;
 static u32 exec_tmout = EXEC_TIMEOUT; /* Configurable exec timeout (ms)   */
 static u32 hang_tmout = EXEC_TIMEOUT; /* Timeout used for hang det (ms)   */
 
@@ -313,6 +313,10 @@ enum {
   /* 04 */ FAULT_NOINST,
   /* 05 */ FAULT_NOBITS
 };
+
+
+
+
 
 
 /* Get unix time in milliseconds */
@@ -2406,6 +2410,33 @@ DWORD WINAPI watchdog_timer( LPVOID lpParam ) {
 	}
 }
 
+char ReadCommandFromPipe()
+{
+	DWORD num_read;
+	char result;
+	do
+	{
+		//this loop prevents us from getting stuck inside a corner case where
+		//the target app is closing between a liveness check and reading from pipe.
+		if (!is_child_running())
+		{
+			return 0;
+		}
+		PeekNamedPipe(pipe_handle, NULL, 0, NULL, &num_read, NULL);
+	} while (num_read == 0);
+
+	ReadFile(pipe_handle, &result, 1, &num_read, NULL);
+	//ACTF("read from pipe '%c'", result);
+	return result;
+}
+
+void WriteCommandToPipe(char cmd)
+{
+	DWORD num_written;
+	//ACTF("write to pipe '%c'", cmd);
+	WriteFile(pipe_handle, &cmd, 1, &num_written, NULL);
+}
+
 static void setup_watchdog_timer() {
 	watchdog_enabled = 0;
 	InitializeCriticalSection(&critical_section);
@@ -2427,8 +2458,6 @@ static int is_child_running() {
 
 static u8 run_target(char** argv, u32 timeout) {
   //todo watchdog timer to detect hangs
-
-  char command[] = "F";
   DWORD num_read;
   char result = 0;
 
@@ -2453,23 +2482,45 @@ static u8 run_target(char** argv, u32 timeout) {
     fuzz_iterations_current = 0;
   }
 
+  DWORD max_readfile_retries = 2; // if we read file more than this amount it means we won't reach target func, thus go to next testcase.
   child_timed_out = 0;
   memset(trace_bits, 0, MAP_SIZE);
   MemoryBarrier();
-
-  WriteFile( 
-    pipe_handle,        // handle to pipe 
-    command,     // buffer to write from 
-    1, // number of bytes to write 
-    &num_read,   // number of bytes written 
-    NULL);        // not overlapped I/O 
-
-
   watchdog_timeout_time = get_cur_time() + timeout;
   watchdog_enabled = 1;
+  //ACTF("app_persistent_mode '%d'", app_persistent_mode);
+  if (app_persistent_mode)
+  {
+	  result = ReadCommandFromPipe();
+	  //until 'prefuzz' keep telling target to proceed with readfiles.
+	  while (result != 'P') 
+	  {
+		  if (result == 0) //saves us from getting stuck.
+		  {
+			  return FAULT_NONE;
+		  }
+		  if (result == 'F') //means last run reached the fuzzed target, just read next signal
+		  {
+			  WriteCommandToPipe('F'); //means target is going to read file.
+		  }
+		  if (result == 'K')
+		  {
+			  if (max_readfile_retries == 0)
+			  {
+				  //ACTF("target function missed - going for next test case.");
+				  return FAULT_NONE;
+			  }
+			  max_readfile_retries--;
+		  }
+		  result = ReadCommandFromPipe();
+	  } 
+	  //we only leave this scope if the target is waiting to execute the target fuzz function.
+  }
 
-  ReadFile(pipe_handle, &result, 1, &num_read, NULL);
+  WriteCommandToPipe('F');
 
+  result = ReadCommandFromPipe(); //no need to check for "error(0)" since we are exiting anyway
+  //ACTF("result: '%c'", result);
   MemoryBarrier();
   watchdog_enabled = 0;
 
@@ -2883,7 +2934,7 @@ static void perform_dry_run(char** argv) {
 
       case FAULT_NOINST:
 
-        FATAL("No instrumentation detected");
+        //FATAL("No instrumentation detected");
 
       case FAULT_NOBITS: 
 
@@ -7488,15 +7539,18 @@ int main(int argc, char** argv) {
 
   optind = 1;
 
+  app_persistent_mode = 0;
   in_dir = NULL;
   out_dir = NULL;
   dynamorio_dir = NULL;
   client_params = NULL;
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dYnCB:S:M:x:QD:b:")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:p:f:m:t:T:dYnCB:S:M:x:QD:b:")) > 0)
 
     switch (opt) {
-
+	  case 'p':
+		app_persistent_mode = 1;
+		break;
       case 'i':
 
         if (in_dir) FATAL("Multiple -i options not supported");

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -315,9 +315,6 @@ enum {
 
 
 
-
-
-
 /* Get unix time in milliseconds */
 
 static u64 get_cur_time(void) {
@@ -2916,7 +2913,7 @@ static void perform_dry_run(char** argv) {
 
       case FAULT_NOINST:
 
-        //FATAL("No instrumentation detected");
+        FATAL("No instrumentation detected");
 
       case FAULT_NOBITS: 
 

--- a/test.cpp
+++ b/test.cpp
@@ -27,80 +27,100 @@
 #include <windows.h>
 #include <string.h>
 
+
+int __declspec(noinline) test_target(char* input_file_path, char* argv_0)
+{
+	return 1;
+	char *crash = NULL;
+	FILE *fp = fopen(input_file_path, "rb");
+	char c;
+	if (!fp) {
+		printf("Error opening file\n");
+		return 0;
+	}
+	if (fread(&c, 1, 1, fp) != 1) {
+		printf("Error reading file\n");
+		fclose(fp);
+		return 0;
+	}
+	if (c != 't') {
+		printf("Error 1\n");
+		fclose(fp);
+		return 0;
+	}
+	if (fread(&c, 1, 1, fp) != 1) {
+		printf("Error reading file\n");
+		fclose(fp);
+		return 0;
+	}
+	if (c != 'e') {
+		printf("Error 2\n");
+		fclose(fp);
+		return 0;
+	}
+	if (fread(&c, 1, 1, fp) != 1) {
+		printf("Error reading file\n");
+		fclose(fp);
+		return 0;
+	}
+	if (c != 's') {
+		printf("Error 3\n");
+		fclose(fp);
+		return 0;
+	}
+	if (fread(&c, 1, 1, fp) != 1) {
+		printf("Error reading file\n");
+		fclose(fp);
+		return 0;
+	}
+	if (c != 't') {
+		printf("Error 4\n");
+		fclose(fp);
+		return 0;
+	}
+	printf("!!!!!!!!!!OK!!!!!!!!!!\n");
+
+	if (fread(&c, 1, 1, fp) != 1) {
+		printf("Error reading file\n");
+		fclose(fp);
+		return 0;
+	}
+	if (c == '1') {
+		// cause a crash
+		crash[0] = 1;
+	}
+	else if (c == '2') {
+		char buffer[5] = { 0 };
+		// stack-based overflow to trigger the GS cookie corruption
+		for (int i = 0; i < 5; ++i)
+			strcat(buffer, argv_0);
+		printf("buffer: %s\n", buffer);
+	}
+	else {
+		printf("Error 5\n");
+	}
+	fclose(fp);
+	return 0;
+}
+
 int main(int argc, char** argv)
 {
-    char *crash = NULL;
-
     if(argc < 2) {
         printf("Usage: %s <input file>\n", argv[0]);
         return 0;
     }
 
-    FILE *fp = fopen(argv[1], "rb");
-    char c;
-    if(!fp) {
-        printf("Error opening file\n");
-        return 0;
-    }
-    if(fread(&c, 1, 1, fp) != 1) {
-        printf("Error reading file\n");
-        fclose(fp);
-        return 0;
-    }
-    if(c != 't') {
-        printf("Error 1\n");
-        fclose(fp);
-        return 0;
-    }
-    if(fread(&c, 1, 1, fp) != 1) {
-        printf("Error reading file\n");
-        fclose(fp);
-        return 0;
-    }
-    if(c != 'e') {
-        printf("Error 2\n");
-        fclose(fp);
-        return 0;
-    }
-    if(fread(&c, 1, 1, fp) != 1) {
-        printf("Error reading file\n");
-        fclose(fp);
-        return 0;
-    }
-    if(c != 's') {
-        printf("Error 3\n");
-        fclose(fp);
-        return 0;
-    }
-    if(fread(&c, 1, 1, fp) != 1) {
-        printf("Error reading file\n");
-        fclose(fp);
-        return 0;
-    }
-    if(c != 't') {
-        printf("Error 4\n");
-        fclose(fp);
-        return 0;
-    }
-    printf("!!!!!!!!!!OK!!!!!!!!!!\n");
-
-    if(fread(&c, 1, 1, fp) != 1) {
-        printf("Error reading file\n");
-        fclose(fp);
-        return 0;
-    }
-    if(c == '1') {
-        // cause a crash
-        crash[0] = 1;
-    } else if(c == '2') {
-        char buffer[5] = { 0 };
-        // stack-based overflow to trigger the GS cookie corruption
-        for(int i = 0; i < 5; ++i)
-            strcat(buffer, argv[0]);
-        printf("buffer: %s\n", buffer);
-    } else {
-        printf("Error 5\n");
-    }
-    fclose(fp);
-    return 0;
+	if (argc == 3 && !strcmp(argv[2], "loop"))
+	{
+		//loop inside application and call target infinitey
+		while (true)
+		{
+			test_target(argv[1], argv[0]);
+		}
+	}
+	else
+	{
+		//regular single target call
+		return test_target(argv[1], argv[0]);
+	}
 }

--- a/test.cpp
+++ b/test.cpp
@@ -30,7 +30,6 @@
 
 int __declspec(noinline) test_target(char* input_file_path, char* argv_0)
 {
-	return 1;
 	char *crash = NULL;
 	FILE *fp = fopen(input_file_path, "rb");
 	char c;

--- a/winafl.c
+++ b/winafl.c
@@ -66,7 +66,7 @@ static uint verbose;
 #define COVERAGE_EDGE 1
 
 //fuzz modes
-enum fuzz_mode_t { default_mode = 0,	in_app_persistent_mode = 1,};
+enum persistence_mode_t { native_mode = 0,	in_app = 1,};
 
 typedef struct _target_module_t {
     char module_name[MAXIMUM_PATH];
@@ -79,7 +79,7 @@ typedef struct _winafl_option_t {
      */
     bool nudge_kills;
     bool debug_mode;
-	int fuzz_mode;
+	int persistence_mode;
     int coverage_kind;
     char logdir[MAXIMUM_PATH];
     target_module_t *target_modules;
@@ -645,11 +645,11 @@ event_module_load(void *drcontext, const module_data_t *info, bool loaded)
                     to_wrap += (size_t)info->start;
                 }
             }
-			if (options.fuzz_mode == default_mode)
+			if (options.persistence_mode == native_mode)
 			{
 				drwrap_wrap_ex(to_wrap, pre_fuzz_handler, post_fuzz_handler, NULL, options.callconv);
 			}
-			if (options.fuzz_mode == in_app_persistent_mode)
+			if (options.persistence_mode == in_app)
 			{
 				drwrap_wrap_ex(to_wrap, pre_loop_start_handler, NULL, NULL, options.callconv);
 			}
@@ -784,7 +784,7 @@ options_init(client_id_t id, int argc, const char *argv[])
     const char *token;
     target_module_t *target_modules;
     /* default values */
-	options.fuzz_mode = default_mode;
+	options.persistence_mode = native_mode;
     options.nudge_kills = true;
     options.debug_mode = false;
     options.thread_coverage = false;
@@ -879,16 +879,16 @@ options_init(client_id_t id, int argc, const char *argv[])
             else
                 NOTIFY(0, "Unknown calling convention, using default value instead.\n");
         }
-		else if (strcmp(token, "-fuzz_mode") == 0) {
+		else if (strcmp(token, "-persistence_mode") == 0) {
 			USAGE_CHECK((i + 1) < argc, "missing mode arg: '-fuzz_mode' arg");
 			const char* mode = argv[++i];
-			if (strcmp(mode, "in_app_persistent") == 0)
+			if (strcmp(mode, "in_app") == 0)
 			{
-				options.fuzz_mode = in_app_persistent_mode;
+				options.persistence_mode = in_app;
 			}
 			else
 			{
-				options.fuzz_mode = default_mode;
+				options.persistence_mode = native_mode;
 			}
 		}
         else {


### PR DESCRIPTION
Hey, I've just added a new switch to winafl: -fuzz_mode in_app_persistent
it will take the normal target_module and target_function/target_offset and hook it into a pre_loop_start_handler instead the pre_fuzz_handler and post_fuzz_handler as we discussed.

If you disagree with something or has any suggestions to make it even better, let me know