### PR TITLE
Enable network fuzzing support for winAFL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ add_executable(test
   test.cpp
   )
 
+project(test_netmode)
+
+add_executable(test_netmode test_netmode.cpp)
+
+
 if(NOT "${CMAKE_GENERATOR}" MATCHES "(Win64)")
 
   project(test_static)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ WinAFL has been successfully used to identify bugs in Windows software, such as
  * [Microsoft] CVE-2016-7212 - found by Aral Yaman of Noser Engineering AG
  * [Microsoft] CVE-2017-0073, CVE-2017-0190, CVE-2017-11816 - found by [Symeon Paraschoudis](https://twitter.com/symeonp) of SensePost
  * [Adobe] CVE-2018-4985, CVE-2018-5063, CVE-2018-5064, CVE-2018-5065, CVE-2018-5068, CVE-2018-5069, CVE-2018-5070, CVE-2018-12754, CVE-2018-12755, CVE-2018-12764, CVE-2018-12765, CVE-2018-12766, CVE-2018-12767, CVE-2018-12768 - found by Yoav Alon and Netanel Ben-Simon from Check Point Software Technologies
+ * [Kollective Kontiki 10.0.1] CVE-2018-11672 - found by Maksim Shudrak from Salesforce
  
 (Let me know if you know of any others and I'll include them in the list)
 
@@ -308,6 +309,23 @@ Examples of use:
 <p align="center">
 <img alt="winafl-cmin.py" src="screenshots/winafl-cmin.py.png"/>
 </p>
+
+## Network fuzzing mode
+
+Recently, WinAFL started supporting of network-based applications fuzzing that receive and parse network data. There are several winAFL options to control this process:
+
+```
+  -a IP address - IP address to send data in
+  -U            - use UDP protocol instead of TCP to send data (default TCP)
+  -p port       - port to send data in
+  -w msec       - delay in milliseconds before actually start fuzzing
+```
+
+Basically, you need to add IP address and port to existent winAFL command line arguments to send your test cases over network. You still need to find target function and make sure that this function receives data from network, parses it, and returns normally. It is very important to emphasize that in case of network-based fuzzing, the option ```-fuzz_iterations``` is considered as a number of test cases winAFL should send over network before it completely restarts
+target application.
+
+Additionally, this mode is considered as experimental since we have experienced some problems with stability and performance. However, we
+found this option very usefull and managed to find several vulnerabilities in network-based applications (e.g. in Kollective Kontiki listed above).
 
 ## Statically instrument a binary via [syzygy](https://github.com/google/syzygy)
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -57,6 +57,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#pragma comment(lib,"ws2_32.lib") //Winsock Library
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined (__OpenBSD__)
 #  include <sys/sysctl.h>
 #endif /* __APPLE__ || __FreeBSD__ || __OpenBSD__ */
@@ -74,10 +75,16 @@ static u8 *in_dir,                    /* Input directory with test cases  */
           *doc_path,                  /* Path to documentation dir        */
           *target_path,               /* Path to target binary            */
           *target_cmd,                /* command line of target           */
-          *orig_cmdline;              /* Original command line            */
+          *orig_cmdline,              /* Original command line            */
+          *target_ip_address = NULL;  /* Target IP to send test cases     */
 
 static u32 exec_tmout = EXEC_TIMEOUT; /* Configurable exec timeout (ms)   */
 static u32 hang_tmout = EXEC_TIMEOUT; /* Timeout used for hang det (ms)   */
+
+static u8  enable_socket_fuzzing = 0; /* Enable network fuzzing           */
+static u8  is_TCP = 1;                /* TCP or UDP                       */
+static u32 target_port = 0x0;         /* Target port to send test cases   */
+static u32 socket_init_delay = SOCKET_INIT_DELAY; /* Socket init delay    */
 
 static u64 mem_limit  = MEM_LIMIT;    /* Memory cap for child (MB)        */
 
@@ -2229,9 +2236,9 @@ static void create_target_process(char** argv) {
   } else {
     pidfile = alloc_printf("childpid_%s.txt", fuzzer_id);
     cmd = alloc_printf(
-      "%s\\drrun.exe -pidfile %s -no_follow_children -c winafl.dll %s -fuzzer_id %s -- %s",
-      dynamorio_dir, pidfile, client_params, fuzzer_id, target_cmd
-    );
+        "%s\\drrun.exe -pidfile %s -no_follow_children -c winafl.dll %s %s -fuzzer_id %s -- %s",
+        dynamorio_dir, pidfile, client_params, (enable_socket_fuzzing == 1) ? "-socket_fuzzing": "",
+        fuzzer_id, target_cmd);
   }
 
   if(mem_limit || cpu_aff) {
@@ -2422,6 +2429,99 @@ static int is_child_running() {
   return ret;
 }
 
+static void send_data_tcp(const char *buf, const int buf_len, int first_time) {
+  static struct sockaddr_in si_other;
+  static int slen = sizeof(si_other);
+  static WSADATA wsa;
+  int s;
+
+  if (first_time == 0x0) {
+    /* wait while the target process open the socket */
+    Sleep(socket_init_delay);
+
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+       FATAL("WSAStartup failed. Error Code : %d", WSAGetLastError());
+
+       // setup address structure
+       memset((char *)&si_other, 0, sizeof(si_other));
+       si_other.sin_family = AF_INET;
+       si_other.sin_port = htons(target_port);
+       si_other.sin_addr.S_un.S_addr = inet_addr((char *)target_ip_address);
+    }
+
+    /* In case of TCP we need to open a socket each time we want to establish
+     * connection. In theory we can keep connections always open but it might
+     * cause our target behave differently (probably there are a bunch of
+     * applications where we should apply such scheme to trigger interesting
+     * behavior).
+     */
+    if ((s = socket(AF_INET, SOCK_STREAM, IPPROTO_IP)) == SOCKET_ERROR)
+      FATAL("socket() failed with error code : %d", WSAGetLastError());
+
+    // Connect to server.
+    if (connect(s, (SOCKADDR *)& si_other, slen) == SOCKET_ERROR)
+      FATAL("connect() failed with error code : %d", WSAGetLastError());
+
+    // Send our buffer
+    if (send(s, buf, buf_len, 0) == SOCKET_ERROR)
+      FATAL("send() failed with error code : %d", WSAGetLastError());
+
+    // shutdown the connection since no more data will be sent
+    if (shutdown(s, 0x1/*SD_SEND*/) == SOCKET_ERROR)
+      FATAL("shutdown failed with error: %d\n", WSAGetLastError());
+}
+
+static void send_data_udp(const char *buf, const int buf_len, int first_time) {
+  static struct sockaddr_in si_other;
+  static int s, slen = sizeof(si_other);
+  static WSADATA wsa;
+
+  if (first_time == 0x0) {
+    /* wait while the target process open the socket */
+    Sleep(socket_init_delay);
+
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+      FATAL("WSAStartup failed. Error Code : %d", WSAGetLastError());
+
+    if ((s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == SOCKET_ERROR)
+      FATAL("socket() failed with error code : %d", WSAGetLastError());
+
+    // setup address structure
+    memset((char *)&si_other, 0, sizeof(si_other));
+    si_other.sin_family = AF_INET;
+    si_other.sin_port = htons(target_port);
+    si_other.sin_addr.S_un.S_addr = inet_addr((char *)target_ip_address);
+  }
+
+  // send the data
+  if (sendto(s, buf, buf_len, 0, (struct sockaddr *) &si_other, slen) == SOCKET_ERROR)
+    FATAL("sendto() failed with error code : %d", WSAGetLastError());
+}
+
+void open_file_and_send_data() {
+  /* open generated file */
+  s32 fd = out_fd;
+  if (out_file != NULL)
+    fd = open(out_file, O_RDONLY | O_BINARY);
+
+  long fsize;
+  fsize = lseek(fd, 0, SEEK_END);
+  lseek(fd, 0, SEEK_SET);
+
+  /* allocate buffer to read the file */
+  char *buf = malloc(fsize + 1);
+  ck_read(fd, buf, fsize, "input file");
+
+  /* send data over TCP or UDP */
+  if (is_TCP)
+    send_data_tcp(buf, fsize, fuzz_iterations_current);
+  else
+    send_data_udp(buf, fsize, fuzz_iterations_current);
+
+  /* free memory */
+  free(buf);
+}
+
 /* Execute target application, monitoring for timeouts. Return status
    information. The called program will update trace_bits[]. */
 
@@ -2452,6 +2552,9 @@ static u8 run_target(char** argv, u32 timeout) {
     create_target_process(argv);
     fuzz_iterations_current = 0;
   }
+
+  if (enable_socket_fuzzing)
+    open_file_and_send_data();
 
   child_timed_out = 0;
   memset(trace_bits, 0, MAP_SIZE);
@@ -6863,6 +6966,12 @@ static void usage(u8* argv0) {
        "  -d            - quick & dirty mode (skips deterministic steps)\n"
        "  -x dir        - optional fuzzer dictionary (see README)\n\n"
 
+	   "Network fuzzing settings:\n\n"
+       "  -a            - IP address to send data in\n"
+       "  -U            - Use UDP (default TCP)\n"
+       "  -p            - Port to send data in\n"
+       "  -w            - Delay in milliseconds before start sending data\n"
+
        "Other stuff:\n\n"
 
        "  -T text       - text banner to show on the screen\n"
@@ -7493,7 +7602,7 @@ int main(int argc, char** argv) {
   dynamorio_dir = NULL;
   client_params = NULL;
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dYnCB:S:M:x:QD:b:")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dYnCB:S:M:x:QD:b:Ua:p:w:")) > 0)
 
     switch (opt) {
 
@@ -7670,11 +7779,38 @@ int main(int argc, char** argv) {
 
         break;
 
+	  case 'a':
+        enable_socket_fuzzing = 1;
+        target_ip_address = ck_strdup(optarg);
+
+        break;
+
+      case 'U':
+        is_TCP = 0;
+
+        break;
+
+      case 'p':
+        enable_socket_fuzzing = 1;
+        if (sscanf(optarg, "%u", &target_port) < 1 ||
+          optarg[0] == '-') FATAL("Bad syntax used for -p");
+
+        break;
+
+      case 'w':
+        if (sscanf(optarg, "%u", &socket_init_delay) < 1 ||
+          optarg[0] == '-') FATAL("Bad syntax used for -w");
+
+        break;
+
       default:
 
         usage(argv[0]);
 
     }
+
+  if (enable_socket_fuzzing && (target_ip_address == NULL || target_port == 0))
+    FATAL("\nYou forgot to specify either target IP address or port\n");
 
   if (!in_dir || !out_dir || !timeout_given || (!drioless && !dynamorio_dir)) usage(argv[0]);
 

--- a/config.h
+++ b/config.h
@@ -52,6 +52,11 @@
 
 #define EXEC_TM_ROUND       20
 
+/* Defauly delay in milliseconds to let the target open a socket and start listen for
+   incoming packages.
+ */
+#define SOCKET_INIT_DELAY 30000
+
 /* Default memory limit for child process (MB): */
 
 #ifndef __x86_64__ 

--- a/test_netmode.cpp
+++ b/test_netmode.cpp
@@ -1,0 +1,107 @@
+/*
+   WinAFL - A simple binary to test winAFL ability perform fuzzing over network:
+   -------------------------------------------------------------
+
+   Written and maintained by Maksim Shudrak <mxmssh@gmail.com>
+
+   Copyright 2018 Salesforce Inc. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+/* cmd line to find the crash:
+ * afl-fuzz.exe -U -p 7714 -a 127.0.0.1 -w 1000 -i in -o out -D ..\..\dr_release\bin32
+ * -t 20000 -- -target_module test_netmode.exe -target_method recv_func -coverage_module test_netmode.exe
+ * -fuzz_iterations 50000 -nargs 1 -- ..\Debug\test_netmode.exe
+ */
+
+#define _CRT_SECURE_NO_WARNINGS
+#include <stdio.h>
+#include <windows.h>
+#include <string.h>
+
+#pragma comment(lib,"ws2_32.lib") //Winsock Library
+
+#define DEFAULT_PORT 7714
+#define BUFSIZE 4096
+
+void error(const char *msg) {
+	printf("[ERROR] %s %d\n", msg, WSAGetLastError());
+    exit(-1);
+}
+
+struct sockaddr_in serveraddr;	  /* server's addr */
+
+void recv_func(int sockfd)
+{	
+    char *buf;
+	struct sockaddr_in clientaddr;	  /* client addr */
+	int clientlen = sizeof(clientaddr);
+    int n = 0;
+
+    buf = (char *)malloc(BUFSIZE);
+
+    /* receiving over UDP */
+    n = recvfrom(sockfd, buf, BUFSIZE, 0, (struct sockaddr *)&clientaddr, &clientlen);
+    if (n < 0)
+        error("ERROR in recvfrom");
+
+    if (buf[0] == 'P') {
+		if (buf[1] == 'W') {
+			if (buf[2] == 'N') {
+				if (buf[3] == 'I') {
+					if (buf[4] == 'T') {
+						printf("Found it!\n");
+						((VOID(*)())0x0)();
+					}
+				}
+			}
+		}
+	}
+
+    printf("Received %d bytes, content = %s\n", n, buf);
+    free(buf);
+}
+
+int main(int argc, char** argv)
+{
+	int sockfd;
+	int portno = DEFAULT_PORT;
+	int optval;
+	static WSADATA wsaData;
+	static int iResult;
+
+	// Initialize Winsock
+	iResult = WSAStartup(MAKEWORD(2, 2), &wsaData);
+
+	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0)
+		error("ERROR opening socket");
+
+	optval = 1;
+    /* UDP */
+	setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (const char *)&optval, sizeof(int));
+
+	memset((char *)&serveraddr, 0, sizeof(serveraddr));
+	serveraddr.sin_family = AF_INET;
+	serveraddr.sin_addr.s_addr = htonl(INADDR_ANY);
+	serveraddr.sin_port = htons((unsigned short)portno);
+
+	if (bind(sockfd, (struct sockaddr *)&serveraddr, sizeof(serveraddr)) < 0)
+		error("ERROR on binding");
+	while (1) {
+		recv_func(sockfd);
+	}
+    return 0;
+}

--- a/winafl.c
+++ b/winafl.c
@@ -89,6 +89,7 @@ typedef struct _winafl_option_t {
     int num_fuz_args;
     drwrap_callconv_t callconv;
     bool thread_coverage;
+    bool enable_socket_fuzzing;
 } winafl_option_t;
 static winafl_option_t options;
 
@@ -445,13 +446,13 @@ pre_fuzz_handler(void *wrapcxt, INOUT void **user_data)
     }
 
     //save or restore arguments
-    if(fuzz_target.iteration == 0) {
-        for(i = 0; i < options.num_fuz_args; i++) {
-            options.func_args[i] = drwrap_get_arg(wrapcxt, i);
-        }
-    } else {
-        for(i = 0; i < options.num_fuz_args; i++) {
-            drwrap_set_arg(wrapcxt, i, options.func_args[i]);
+    if (!options.enable_socket_fuzzing) {
+        if (fuzz_target.iteration == 0) {
+            for (i = 0; i < options.num_fuz_args; i++)
+                options.func_args[i] = drwrap_get_arg(wrapcxt, i);
+        } else {
+            for (i = 0; i < options.num_fuz_args; i++)
+                drwrap_set_arg(wrapcxt, i, options.func_args[i]);
         }
     }
 
@@ -478,6 +479,10 @@ post_fuzz_handler(void *wrapcxt, void *user_data)
         debug_data.post_handler_called++;
         dr_fprintf(winafl_data.log, "In post_fuzz_handler\n");
     }
+
+    /* We don't need to reload context in case of network-based fuzzing. */
+    if (options.enable_socket_fuzzing)
+        return;
 
     fuzz_target.iteration++;
     if(fuzz_target.iteration == options.fuzz_iterations) {
@@ -517,6 +522,20 @@ verfierstopmessage_interceptor_pre(void *wrapctx, INOUT void **user_data)
     exception_record.ExceptionCode = STATUS_HEAP_CORRUPTION;
 
     onexception(NULL, &dr_exception);
+}
+
+static void
+recvfrom_interceptor(void *wrapcxt, INOUT void **user_data)
+{
+    if (options.debug_mode)
+        dr_fprintf(winafl_data.log, "In recvfrom\n");
+}
+
+static void
+recv_interceptor(void *wrapcxt, INOUT void **user_data)
+{
+    if (options.debug_mode)
+        dr_fprintf(winafl_data.log, "In recv\n");
 }
 
 static void
@@ -588,6 +607,13 @@ event_module_load(void *drcontext, const module_data_t *info, bool loaded)
                 }
             }
             drwrap_wrap_ex(to_wrap, pre_fuzz_handler, post_fuzz_handler, NULL, options.callconv);
+        }
+
+        if (options.debug_mode && (strcmp(module_name, "WS2_32.dll") == 0)) {
+            to_wrap = (app_pc)dr_get_proc_address(info->handle, "recvfrom");
+            bool result = drwrap_wrap(to_wrap, recvfrom_interceptor, NULL);
+            to_wrap = (app_pc)dr_get_proc_address(info->handle, "recv");
+            result = drwrap_wrap(to_wrap, recv_interceptor, NULL);
         }
 
         if(options.debug_mode && (strcmp(module_name, "KERNEL32.dll") == 0)) {
@@ -728,6 +754,7 @@ options_init(client_id_t id, int argc, const char *argv[])
     options.fuzz_method[0] = 0;
     options.fuzz_offset = 0;
     options.fuzz_iterations = 1000;
+    options.enable_socket_fuzzing = false;
     options.func_args = NULL;
     options.num_fuz_args = 0;
     options.callconv = DRWRAP_CALLCONV_DEFAULT;
@@ -812,6 +839,9 @@ options_init(client_id_t id, int argc, const char *argv[])
                 options.callconv = DRWRAP_CALLCONV_MICROSOFT_X64;
             else
                 NOTIFY(0, "Unknown calling convention, using default value instead.\n");
+        }
+        else if (strcmp(token, "-socket_fuzzing") == 0) {
+            options.enable_socket_fuzzing = true;
         }
         else {
             NOTIFY(0, "UNRECOGNIZED OPTION: \"%s\"\n", token);


### PR DESCRIPTION
This commit enables network-based applications fuzzing over TCP and UDP protocols.
This commit has test application to verify that network-based fuzzing actually works.